### PR TITLE
delete-utility-classes-from-promotion

### DIFF
--- a/views/sdk/_common/components/promotion-banner.blade.php
+++ b/views/sdk/_common/components/promotion-banner.blade.php
@@ -1,18 +1,14 @@
 @php($campaign = \Ls\ClientAssistant\Utilities\Modules\Campaign::primaryCampaign()->get('data'))
 @if(!empty($campaign))
-    <a href="{{ $campaign['landing_url'] }}" class="promotion-banner d-flex" id="promotion-banner"
-       style=" background: rgb(85,85,85);background: radial-gradient(circle, rgba(85,85,85,1) 0%, rgba(24,24,24,1) 100%);">
+    <a href="{{ $campaign['landing_url'] }}" class="promotion-banner d-flex" id="promotion-banner">
         <div class="container">
             <div class="row">
                 <div class="col px-0--sm">
-                    <div class="alert text-secondary bg-transparent px-0 justify-content-center text-center">
+                    <div class="alert text-secondary bg-transparent px-0  text-center">
                         <span class="title text-white pe-xs d-flex align-items-center gap-sm gap-xs--lg flex-column flex-lg-row">
-{{--                            <img class="icon md w-inherit" src="{{ asset_url('img/icons/blackfriday.svg') }}"--}}
-                            {{--                                 alt="{{ $campaign['title'] }}">--}}
                             {!! $campaign['description'] !!}</span>
-
                         @include('sdk._common.components.countdown-box', [
-                            'class'=>'sm mx-auto me-lg-auto ms-lg-0',
+                            'class'=>'sm',
                             'date' => $campaign['ends_at'],
                             'bg' => '#F29425'
                         ])


### PR DESCRIPTION
توضیحات:کلاسهای utility  و استالهای اینلاین از بنر پروموشن حذف شد و استایلهای پروموشن داخل client-common-components گذاشته شد تا در همه کلاینتها قابل استفاده باشه .مرج ریکوست سمت کلاینت و رودکی نیز زده شد.