### PR TITLE
fix-theme-color-overwrite

### DIFF
--- a/views/sdk/_common/layouts/head.blade.php
+++ b/views/sdk/_common/layouts/head.blade.php
@@ -1,7 +1,7 @@
 {!! setting('top_of_head_script') !!}
+@include('_common.layouts.head')
 @php $theme = get_current_theme(); @endphp
 @if($theme != null)
     {!! $theme['rendered_css'] !!}
 @endif
-@include('_common.layouts.head')
 {!! setting('bottom_of_head_script') !!}

--- a/views/sdk/pages/landing-partials/head.blade.php
+++ b/views/sdk/pages/landing-partials/head.blade.php
@@ -1,8 +1,4 @@
 {{ setting('top_of_head_script') }}
-@php $theme = get_current_theme(); @endphp
-@if($theme != null)
-    {!! $theme['rendered_css'] !!}
-@endif
 
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
@@ -37,3 +33,7 @@
 {{ setting('bottom_of_head_script') }}
 <meta name='description' content='{{ $product['seo']['description'] ?? '' }}' />
 <link rel="stylesheet" href="{{ core_asset('resources/assets/minimal-landing/css/style.scss') }}">
+@php $theme = get_current_theme(); @endphp
+@if($theme != null)
+    {!! $theme['rendered_css'] !!}
+@endif


### PR DESCRIPTION
لینک تسک:https://trello.com/c/xYS5DOvx

توضیحات:به دلیل اینکه theme-colors قبل از layouts.head رندر میشد این رنگها توسط استایلهای دیفالت هر پروژه overwrite   میشد .این تم به پایین تر از layouts.head منتقل شد.این کار سمت مینیمال لندینگ نیز انجام شد

تست:سمت پنل  lsp تم رنگ را تغییر دهید و در کلاینتها تست کنید ببنید تم تغییر کرده یا نه