### PR TITLE
Set verification middleware globally

### DIFF
--- a/sdk/Core/Kernel.php
+++ b/sdk/Core/Kernel.php
@@ -7,6 +7,8 @@ use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\View\Engines\EngineResolver;
 use Ls\ClientAssistant\Core\Middlewares\CorsMiddleware;
+use Ls\ClientAssistant\Core\Middlewares\EmailVerificationMiddleware;
+use Ls\ClientAssistant\Core\Middlewares\MobileVerificationMiddleware;
 use Ls\ClientAssistant\Core\Middlewares\StaticCacheMiddleware;
 use Ls\ClientAssistant\Core\Middlewares\UtmLogMiddleware;
 use Ls\ClientAssistant\Core\Router\App;
@@ -27,7 +29,9 @@ class Kernel
     private array $globalMiddlewares = [
         CorsMiddleware::class,
         StaticCacheMiddleware::class,
-        UtmLogMiddleware::class
+        UtmLogMiddleware::class,
+        EmailVerificationMiddleware::class,
+        MobileVerificationMiddleware::class,
     ];
 
     public function boot(string $envPath, string $routesPath)

--- a/sdk/Core/Middlewares/EmailVerificationMiddleware.php
+++ b/sdk/Core/Middlewares/EmailVerificationMiddleware.php
@@ -8,12 +8,17 @@ class EmailVerificationMiddleware
 {
     public function handle($request, $next)
     {
+        if (!User::loggedIn()) {
+            return $next($request);
+        }
+
         $verificationFields = get_verification_fields();
         if (in_array('email', $verificationFields) && !User::emailVerified()) {
+            $refer = $request->url();
             redirect(
                 setting('user_have_access_to_panel', false)
-                    ? core_url('verification-fields/verify')
-                    : site_url('verification-fields/verify')
+                    ? core_url("verification-fields/verify?refer={$refer}")
+                    : site_url("verification-fields/verify?refer={$refer}")
             );
         }
 

--- a/sdk/Core/Middlewares/MobileVerificationMiddleware.php
+++ b/sdk/Core/Middlewares/MobileVerificationMiddleware.php
@@ -8,12 +8,17 @@ class MobileVerificationMiddleware
 {
     public function handle($request, $next)
     {
+        if (!User::loggedIn()) {
+            return $next($request);
+        }
+
         $verificationFields = get_verification_fields();
         if (in_array('mobile', $verificationFields) && !User::mobileVerified()) {
+            $refer = $request->url();
             redirect(
                 setting('user_have_access_to_panel', false)
-                    ? core_url('verification-fields/verify')
-                    : site_url('verification-fields/verify')
+                    ? core_url("verification-fields/verify?refer={$refer}")
+                    : site_url("verification-fields/verify?refer={$refer}")
             );
         }
 


### PR DESCRIPTION
توضیحات:

میدلویر های EmailVerificationMiddleware , MobileVerificationMiddleware را بصورت گلوبالی روی همه روت ها ست کردم ولی درصورتی که کاربر لاگین نباشد این روت ها هیچ کار خاصی انجام نخواهند داد.

این تغییر برای رفع مشکل مربوط به ریدایرکت درست کاربر بعد از verify کردن ایمیل یا شماره موبایل میباشد.

Task: https://trello.com/c/RhffdAfU