### PR TITLE
Ignored verification routes on verification middleware

### DIFF
--- a/sdk/Core/Middlewares/AuthMiddleware.php
+++ b/sdk/Core/Middlewares/AuthMiddleware.php
@@ -19,10 +19,12 @@ class AuthMiddleware
             redirect(site_url('auth'));
         }
 
-        if (in_array($request->getUri(), [
-            site_url('auth/logout'), site_url('verification-fields/verify'),
-            site_url('auth/email/update'), site_url('auth/mobile/update')
-        ])) {
+        if ($request->is(
+            'auth/logout',
+            'verification-fields/verify',
+            'auth/email/update',
+            'auth/mobile/update'
+        )) {
             return $next($request);
         }
 

--- a/sdk/Core/Middlewares/EmailVerificationMiddleware.php
+++ b/sdk/Core/Middlewares/EmailVerificationMiddleware.php
@@ -12,6 +12,15 @@ class EmailVerificationMiddleware
             return $next($request);
         }
 
+        if ($request->is(
+            'auth/logout',
+            'verification-fields/verify',
+            'auth/email/update',
+            'auth/mobile/update'
+        )) {
+            return $next($request);
+        }
+
         $verificationFields = get_verification_fields();
         if (in_array('email', $verificationFields) && !User::emailVerified()) {
             $refer = $request->url();

--- a/sdk/Core/Middlewares/MobileVerificationMiddleware.php
+++ b/sdk/Core/Middlewares/MobileVerificationMiddleware.php
@@ -12,6 +12,15 @@ class MobileVerificationMiddleware
             return $next($request);
         }
 
+        if ($request->is(
+            'auth/logout',
+            'verification-fields/verify',
+            'auth/email/update',
+            'auth/mobile/update'
+        )) {
+            return $next($request);
+        }
+
         $verificationFields = get_verification_fields();
         if (in_array('mobile', $verificationFields) && !User::mobileVerified()) {
             $refer = $request->url();


### PR DESCRIPTION
توضیحات:


بعد از تنظیم میدلویر های EmailVerificationMiddleware و MobileVerificationMiddleware به عنوان GlobalMiddleware مشکلی که به وجود آمده بود این بود که در صفحه verify ایمیل و شماره تماس مجدد این میدلویر ها اعمال میشد و باعث شده بود ارور too many redirect داشته باشیم.


تست:

بررسی کنید بعد از ثبت نام کاربر به صفحه verification دسترسی داشته باشه 

آدرس صفحه: your-client/verification-fields/verify 

Task: https://trello.com/c/iB82BrTE