### PR TITLE
fix-video-caption

### DIFF
--- a/views/sdk/pwa/_partials/scripts.blade.php
+++ b/views/sdk/pwa/_partials/scripts.blade.php
@@ -20,16 +20,16 @@ function removeTagsKeepContents(selector) {
     });
 }
 
-function toggleMoreText() {
-    var textContainer = document.querySelector('.longtextwrap');
-    var button = document.querySelector('.moretext');
+function toggleMoreText(e) {
+    const  button = $(e.target);    
+    const textContainer=button.closest('.longtextwrap');
 
-    if (textContainer.classList.contains('expanded')) {
-        textContainer.classList.remove('expanded');
-        button.textContent = "ادامه توضیحات ...";
+    if (textContainer.hasClass('expanded')) {
+        textContainer.removeClass('expanded');
+        button.text("ادامه توضیحات ...");
     } else {
-        textContainer.classList.add('expanded');
-        button.textContent = "بستن توضیحات";
+        textContainer.addClass('expanded');
+        button.text("بستن توضیحات");
     }
 }
 

--- a/views/sdk/pwa/course-screen/partials/player.blade.php
+++ b/views/sdk/pwa/course-screen/partials/player.blade.php
@@ -42,7 +42,7 @@
 <div class="longtextwrap">
     <?php if($len > 400): ?>
         <div class="longtext"><?= $item['description']?></div>
-        <span class="moretext" onclick="toggleMoreText()">ادامه توضیحات ...</span>
+        <span class="moretext" onclick="toggleMoreText(event)">ادامه توضیحات ...</span>
     <?php else: ?>
         <div class="alltext"><?= $item['description']?></div>
     <?php endif; ?>


### PR DESCRIPTION
لینک تسک:https://trello.com/c/K9IaCV4F

توضیحات:در دوره های مادام کیک بجز برای ویدیو اول برای بقیه ویدیو ها از سمت بک اند مقدار description خالی میومد.بنابراین مجبور شدم دیتای استاتیک را جایگزین کنم و این مشکل نمایش کپشن را فیکس کنم.این مشکل مربوط به کدهای جاوااسکریپت برای نمایش کپشن بود که فیکس شد.

تست:در لیست دورها بر روی ویدیو یک دوره کلیک کنید و دکمه "ادامه توضیحات ..." را بزنید و بعد دکمه "بستن توضیحات" را بزنید.