### PR TITLE
Log out the user if a 403 response is received

### DIFF
--- a/sdk/Core/API.php
+++ b/sdk/Core/API.php
@@ -44,6 +44,11 @@ class API
 
         $response = self::parseData($response, $httpCode);
 
+        if($httpCode === Response::HTTP_FORBIDDEN && $response->get('message') === 'You are not logged in.') {
+            User::clearUserKeyCookie();
+            exit;
+        }
+
         if ($httpCode === Response::HTTP_MULTI_STATUS && isset($response['data']['redirect'])) {
             header('Location: '.$response['data']['redirect'], true, $response['data']['code']);
             exit;
@@ -90,7 +95,14 @@ class API
         $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
 
-        return self::parseData($response, $httpCode);
+        $response = self::parseData($response, $httpCode);
+
+        if($httpCode === Response::HTTP_FORBIDDEN && $response->get('message') === 'You are not logged in.') {
+            User::clearUserKeyCookie();
+            exit;
+        }
+
+        return $response;
     }
 
     public static function post(string $uri, array $formParams = [], array $headers = []): Collection
@@ -111,7 +123,14 @@ class API
         $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
 
-        return self::parseData($response, $httpCode);
+        $response = self::parseData($response, $httpCode);
+
+        if($httpCode === Response::HTTP_FORBIDDEN && $response->get('message') === 'You are not logged in.') {
+            User::clearUserKeyCookie();
+            exit;
+        }
+
+        return $response;
     }
 
     public static function patch(string $uri, array $formParams = [], array $headers = []): Collection
@@ -133,7 +152,14 @@ class API
         $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
 
-        return self::parseData($response, $httpCode);
+        $response = self::parseData($response, $httpCode);
+
+        if($httpCode === Response::HTTP_FORBIDDEN && $response->get('message') === 'You are not logged in.') {
+            User::clearUserKeyCookie();
+            exit;
+        }
+
+        return $response;
     }
 
     public static function delete(string $uri, array $formParams = [], array $headers = []): Collection
@@ -154,7 +180,14 @@ class API
         $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
 
-        return self::parseData($response, $httpCode);
+        $response = self::parseData($response, $httpCode);
+
+        if($httpCode === Response::HTTP_FORBIDDEN && $response->get('message') === 'You are not logged in.') {
+            User::clearUserKeyCookie();
+            exit;
+        }
+
+        return $response;
     }
 
     public static function parseData($response, $statusCode): Collection

--- a/sdk/Utilities/Modules/User.php
+++ b/sdk/Utilities/Modules/User.php
@@ -323,7 +323,7 @@ class User extends ModuleUtility
     
     public static function tokenExists(): ?string
     {
-        return $_COOKIE['token'] ?? false;
+        return $_COOKIE['token'] ?? null;
     }
 
     public static function resume($id): Collection


### PR DESCRIPTION
در حالتی که کاربر به هرشکلی غیر از روش مرسوم از سیستم خارج شود و یا اینکه توکن فعلی کاربر از دست برود، چون اطلاعات کاربر در کوکی ذخیره میشه کلاینت متوجه لاگین نبودن کاربر نمی شود.

برای رفع این مشکل در این مرج ریکوئست زمانی که response دریافتی کاربر ۴۰۳ باشد و حاوی پیغام شما لاگین نیستید باشد کش ها سمت کلاینت پاک میشود تا کلاینت متوجه لاگین نبودن کاربر بشود.

Task: https://trello.com/c/ZdHllCS5