### PR TITLE
 Display a clear and detailed error message to the client 

### DIFF
--- a/framework_helpers.php
+++ b/framework_helpers.php
@@ -165,21 +165,33 @@ if (!function_exists('is_active_uri_param')) {
 }
 
 if (!function_exists('abort')) {
-    function abort(int $code, string $message = '', string $buttonText = null, string $buttonUrl = null, array $headers = [])
-    {
+    function abort(
+        int    $code,
+        string $message = '',
+        string $buttonText = null,
+        string $buttonUrl = null,
+        array  $headers = []
+    ) {
         http_response_code($code);
-        foreach ($headers as $header) header($header);
+        foreach ($headers as $header) {
+            header($header);
+        }
 
         send_abort_notification($code);
 
-        if (!\Ls\ClientAssistant\Core\Router\WebResponse::viewExist("errors.$code")) {
-            $code = 404;
+        if (\Ls\ClientAssistant\Core\Router\WebResponse::viewExist("errors.$code")) {
+            \Ls\ClientAssistant\Core\Router\WebResponse::view(
+                "errors.$code",
+                compact('code', 'message', 'buttonText', 'buttonUrl')
+            );
+        } else {
+            \Ls\ClientAssistant\Core\Router\WebResponse::view(
+                "sdk.default-error",
+                compact('code', 'message', 'buttonText', 'buttonUrl')
+            );
         }
-
-        \Ls\ClientAssistant\Core\Router\WebResponse::view("errors.$code", compact('code', 'message', 'buttonText', 'buttonUrl'));
         die();
     }
-
 }
 
 if (!function_exists('send_abort_notification')) {

--- a/sdk/Controllers/AuthVerificationController.php
+++ b/sdk/Controllers/AuthVerificationController.php
@@ -34,28 +34,26 @@ class AuthVerificationController
 
     public function send(Request $request)
     {
-        $response = Authentication::sendVerificationCode(
-            $request->get('input'),
-            ['g-recaptcha-response' => $request->get('g-recaptcha-response')]
+        $response = get_or_fail(
+            Authentication::sendVerificationCode(
+                $request->get('input'),
+                ['g-recaptcha-response' => $request->get('g-recaptcha-response')]
+            )
         );
-        if (!$response->get('success')) {
-            return JsonResponse::unprocessableEntity($response->get('message'));
-        }
 
         return JsonResponse::success($response->get('message'));
     }
 
     public function verify(Request $request)
     {
-        $response = Authentication::verifyVerificationFields(
-            $request->cookies->get('token'),
-            $request->get('input'),
-            $request->get('otp'),
-            ['g-recaptcha-response' => $request->get('g-recaptcha-response')]
+        $response = get_or_fail(
+            Authentication::verifyVerificationFields(
+                $request->cookies->get('token'),
+                $request->get('input'),
+                $request->get('otp'),
+                ['g-recaptcha-response' => $request->get('g-recaptcha-response')]
+            )
         );
-        if (!$response->get('success')) {
-            return JsonResponse::unprocessableEntity($response->get('message'));
-        }
 
         return JsonResponse::success($response->get('message'));
     }

--- a/sdk/Controllers/CartController.php
+++ b/sdk/Controllers/CartController.php
@@ -22,7 +22,10 @@ class CartController
 
     public function checkout(Request $request)
     {
-        $cart = Cart::screen(['coupon', 'lmsProductItems.entity', 'lmsProductItems.coupon'])['data'] ?? [];
+        $response = get_or_fail(
+            Cart::screen(['coupon', 'lmsProductItems.entity', 'lmsProductItems.coupon'])
+        );
+        $cart = $response['data'] ?? [];
         $defaultGateway = Gateway::getDefault([], $request->get('gateway'));
         $view = WebResponse::viewExist('salesflow.cart.index') ?
             'salesflow.cart.index' :
@@ -33,7 +36,10 @@ class CartController
 
     public function gateways(Request $request)
     {
-        $cart = Cart::screen(['coupon', 'lmsProductItems.entity', 'lmsProductItems.coupon'])['data'] ?? [];
+        $response = get_or_fail(
+            Cart::screen(['coupon', 'lmsProductItems.entity', 'lmsProductItems.coupon'])
+        );
+        $cart = $response['data'] ?? [];
         $gateways = Gateway::list()->get('data');
         $defaultGateway = Gateway::getDefault($gateways, $request->get('gateway'));
         $eligibleResponse = [];
@@ -59,65 +65,58 @@ class CartController
             );
         }
 
-        $res = Cart::addItem(
-            base64_decode($request->get('et')),
-            (int) $request->get('ei'),
-            $request->get('coupon'),
-            $request->getClientIp()
+        $response = get_or_fail(
+            Cart::addItem(
+                base64_decode($request->get('et')),
+                (int) $request->get('ei'),
+                $request->get('coupon'),
+                $request->getClientIp()
+            )
         );
 
-        if (! $res->get('success')) {
-            return JsonResponse::unprocessableEntity($res->get('message') ?? '');
-        }
-
         return JsonResponse::success(
-            $res->get('message'),
+            $response->get('message'),
             ['backUrl' => route('cart.checkout')]
         );
     }
 
     public function delete(Request $request, $itemId)
     {
-        $res = Cart::deleteItem($itemId);
-        if (! $res->get('success')) {
-            return JsonResponse::unprocessableEntity($res->get('message') ?? '');
-        }
+        $response = get_or_fail(
+            Cart::deleteItem($itemId)
+        );
 
-        return JsonResponse::success($res->get('message'));
+        return JsonResponse::success($response->get('message'));
     }
 
     public function applyCoupon(Request $request, $cart)
     {
-        $res = Coupon::apply(
-            $request->cookies->get('token'),
-            $cart,
-            $request->request->get('coupon')
+        $response = get_or_fail(
+            Coupon::apply(
+                $request->cookies->get('token'),
+                $cart,
+                $request->request->get('coupon')
+            )
         );
 
-        if (! $res->get('success')) {
-            return JsonResponse::unprocessableEntity($res->get('message') ?? '');
-        }
-
         return JsonResponse::success(
-            $res->get('message'),
+            $response->get('message'),
             ['backUrl' => route('cart.checkout')]
         );
     }
 
     public function unapplyCoupon(Request $request, $cart, $coupon)
     {
-        $res = Coupon::unapply(
-            $request->cookies->get('token'),
-            $cart,
-            $coupon
+        $response = get_or_fail(
+            Coupon::unapply(
+                $request->cookies->get('token'),
+                $cart,
+                $coupon
+            )
         );
 
-        if (! $res->get('success')) {
-            return JsonResponse::unprocessableEntity($res->get('message') ?? '');
-        }
-
         return JsonResponse::success(
-            $res->get('message'),
+            $response->get('message'),
             ['backUrl' => route('cart.checkout')]
         );
     }

--- a/sdk/Controllers/MiniLandingController.php
+++ b/sdk/Controllers/MiniLandingController.php
@@ -14,12 +14,8 @@ class MiniLandingController
     {
         $filter = ModuleFilter::new()
             ->includes('productGifts', 'mainTeacherFaculty', 'publishedChapters.log', 'publishedChapters.publishedItems.log');
-        $response = LMSProduct::get($slug, $filter);
-        if (! $response->get('success')) {
-            abort(404, 'محصول پیدا نشد');
-        }
+        $response = get_or_fail(LMSProduct::get($slug, $filter));
         $product = $response->get('data');
-
         $brandNameEn = setting('brand_name_en');
         $currentUser = current_user();
         $introVideo = get_media_url($product['intro_video'], $product['meta']['demo_video_urls'][0] ?? '');
@@ -42,10 +38,7 @@ class MiniLandingController
 
     public function payDetails(string $slug)
     {
-        $response = LMSProduct::get($slug);
-        if (! $response->get('success')) {
-            return JsonResponse::notFound('محصول پیدا نشد.');
-        }
+        $response = get_or_fail(LMSProduct::get($slug));
         $product = $response->get('data');
         if (! $product['is_on_sale']) {
             return JsonResponse::notFound('ثبت نام این دوره در حال حاضر متوقف شده است.');
@@ -71,12 +64,8 @@ class MiniLandingController
     {
         $filter = ModuleFilter::new()
             ->includes('productGifts', 'mainTeacherFaculty', 'publishedChapters.log', 'publishedChapters.publishedItems.log');
-        $response = LMSProduct::get($slug, $filter);
-        if (! $response->get('success')) {
-            abort(404, 'محصول پیدا نشد');
-        }
+        $response = get_or_fail(LMSProduct::get($slug, $filter));
         $product = $response->get('data');
-
         $brandNameEn = setting('brand_name_en');
         $currentUser = current_user();
         $introVideo = get_media_url($product['intro_video'], $product['meta']['demo_video_urls'][0] ?? '');

--- a/sdk/Controllers/PageController.php
+++ b/sdk/Controllers/PageController.php
@@ -10,7 +10,9 @@ class PageController
 {
     public function find(Request $request, $slug)
     {
-        $response = get_or_fail(CMS::get($slug, ['comments', 'comments.user', 'comments.parent']), 'برگه مورد نظر یافت نشد');
+        $response = get_or_fail(
+            CMS::get($slug, ['comments', 'comments.user', 'comments.parent']),
+        );
         $page = $response['data'];
         if ($page['type'] != 'page') {
             abort(404, 'برگه مورد نظر یافت نشد');

--- a/sdk/Controllers/WorkflowFormController.php
+++ b/sdk/Controllers/WorkflowFormController.php
@@ -21,11 +21,7 @@ class WorkflowFormController
         }else{
             $response = ObjectCache::write($key, TaskManager::formData($workflow));
         }
-        
-        if (!$response->get('success')) {
-            abort(404);
-        }
-
+        $response = get_or_fail($response);
         $workflowData = $response->get('data');
 
         $courses = [];
@@ -76,9 +72,7 @@ class WorkflowFormController
             'source' => $request->get('source'),
         ]);
 
-        if (!$response->get('success')) 
-            return JsonResponse::unprocessableEntity($response->get('message') ?? 'مطممئن شوید اطلاعات فرم را به درستی وارد کرده اید');
-        
+        $response = get_or_fail($response, 'مطممئن شوید اطلاعات فرم را به درستی وارد کرده اید');
         if (mb_substr($firstName, -1) === 'ا') // نادیا عزیز => نادیای عزیز
             $firstName .= 'ی';
 

--- a/sdk/Core/Kernel.php
+++ b/sdk/Core/Kernel.php
@@ -20,6 +20,8 @@ use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\Router;
 use Illuminate\Http\Request;
 use Illuminate\Container\Container;
+use Ls\ClientAssistant\Core\Router\JsonResponse;
+use Ls\ClientAssistant\Exceptions\UnprocessableContent;
 
 class Kernel
 {
@@ -131,10 +133,14 @@ class Kernel
 
     protected function sendRequestThroughRouter($request)
     {
-        return (new Pipeline($this->container))
-            ->send($request)
-            ->through($this->globalMiddlewares)
-            ->then($this->dispatchToRouter());
+        try {
+            return (new Pipeline($this->container))
+                ->send($request)
+                ->through($this->globalMiddlewares)
+                ->then($this->dispatchToRouter());
+        }catch (UnprocessableContent $exception) {
+            return JsonResponse::unprocessableEntity($exception->getMessage());
+        }
     }
 
     protected function dispatchToRouter()

--- a/sdk/Exceptions/UnprocessableContent.php
+++ b/sdk/Exceptions/UnprocessableContent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ls\ClientAssistant\Exceptions;
+
+class UnprocessableContent extends \Exception
+{
+    public static function instance(string $message): self
+    {
+        return new self($message);
+    }
+}

--- a/views/sdk/default-error.blade.php
+++ b/views/sdk/default-error.blade.php
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>{{ $code }} Error</title>
+    <link href=
+                  "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
+          rel="stylesheet" />
+    <style>
+        body,
+        html {
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body class="d-flex justify-content-center align-items-center">
+<div class="col-md-12 text-center">
+    <h1>{{ $code }}</h1>
+    <p>{{ $message }}</p>
+</div>
+</body>
+
+</html>


### PR DESCRIPTION
##### بررسی وضعیت پاسخ درخواست های API پیاده سازی شد

لاجیک بررسی وضعیت رسپانس درخواست ها و اینکه باید چه اقدامی در قبال هر رسپانس صورت بگیره به SDK منتقل شد 

و تغییرات شامل موارد زیر هستش 
- هلپر get_or_fail اصلاح شد تا با توجه به وضعیت رسپانس و نوع آن اقدام متناسبی داشته باشد
- یک صفحه error بصورت پیشفرض به sdk اضافه شد تا اگر کلاینت صفحات اختصاصی ارور ها مثل ۴۰۴ یا ۵۰۰ رو نداشت این صفحه به کاربر نمایش داده شود.
- کنترلر های موجود در SDK هم مطابق استاندارد جدید ریفکتور شد و منتقل بررسی رسپانس از این کنترلر ها حذف گردید
- یک ارور کاستوم به اسم UnprocessableContent برای درخواست های Ajax که با رسپانس ۴۲۲ مواجه میشن ایجاد شد و این ارور در هلپر get_or_fail پرت میشه و در کرنل catch میشه تا نتیجه به درستی به کاربر نمایش داده شود.