### PR TITLE
feat: Add support for special second-level domains (SLD)

### DIFF
--- a/framework_helpers.php
+++ b/framework_helpers.php
@@ -368,6 +368,8 @@ if (!function_exists('get_cookie_domain')) {
     {
         $currentHostUrl = parse_url(request()->url(), PHP_URL_HOST);
         $foreignHostUrl = null;
+        $specialDomains = ['ac.ir', 'gov.ir', 'co.ir'];
+
         if (env('CORE_URL')) {
             $foreignHostUrl = parse_url(env('CORE_URL'), PHP_URL_HOST);
         } elseif (!is_null(setting('_env_client_url'))) {
@@ -381,6 +383,15 @@ if (!function_exists('get_cookie_domain')) {
         $urlParts = explode('.', $currentHostUrl);
         $topLevelDomain = end($urlParts);
         $secondLevelDomain = $urlParts[count($urlParts) - 2] ?? '';
+
+        if (count($urlParts) > 2) {
+            $domainEnd = $urlParts[count($urlParts) - 2] . '.' . $urlParts[count($urlParts) - 1];
+            if (in_array($domainEnd, $specialDomains)) {
+                $subDomain = $urlParts[count($urlParts) - 3];
+                return ".$subDomain.$domainEnd";
+            }
+        }
+
         if (empty($secondLevelDomain)) {
             return '';
         }


### PR DESCRIPTION
در این PR، تابع helper مربوط به `get_cookie_domain` بهبود یافت تا بتواند دامنه‌های با ساختار خاص را به درستی مدیریت کند. 

این تغییر به طور خاص برای دامنه‌هایی مانند `new.fhakim.ac.ir` انجام شد، که در آن‌ها بخش‌هایی مثل `ac.ir` یک Second-Level Domain (SLD) محسوب می‌شوند و باید به عنوان یک واحد در نظر گرفته شوند.

با این بهبود، تابع می‌تواند domain صحیح را برای استفاده در `setcookie` تشخیص داده و برگرداند.