### PR TITLE
fix http HTTP_REFERER variable for server super global

### DIFF
--- a/sdk/Controllers/AuthController.php
+++ b/sdk/Controllers/AuthController.php
@@ -21,7 +21,7 @@ class AuthController
         if($backurl){
             return $backurl;
         }
-        if(str_contains($_SERVER['HTTP_REFERER'],$_SERVER['HTTP_HOST']))
+        if(isset($_SERVER['HTTP_REFERER']) && str_contains($_SERVER['HTTP_REFERER'],$_SERVER['HTTP_HOST']))
             return $_SERVER['HTTP_REFERER'];
         return site_url('pwa/dashboard');
     }


### PR DESCRIPTION
وقتی HTTP_REFERER در سوپر گلوبال $_SERVER مقدار نداشت به خطا میخورد کامل صفحه که در این pr فیکس شد