### PR TITLE
Fixed quick pay

### DIFF
--- a/sdk/Controllers/QPayController.php
+++ b/sdk/Controllers/QPayController.php
@@ -105,7 +105,6 @@ class QPayController
             site_url('payment/callback'),
             $gateway,
             $request->coupon,
-            site_url('payment/verify')
         );
 
         return JsonResponse::json(


### PR DESCRIPTION
به این دلیل که آدرس بازگشتی برای درگاه اسنپ پی معتبر نبود مجبور به استفاده از آدرس برگشتی پیش فرض شدیم

Task: https://trello.com/c/WR2NLMz6