### PR TITLE
fixed redirect form in payments

### DIFF
--- a/views/sdk/salesflow/qpay/index.blade.php
+++ b/views/sdk/salesflow/qpay/index.blade.php
@@ -411,7 +411,7 @@
                 form.action = data.url;
 
                 for (const key in data['payload']) {
-                    if (data.hasOwnProperty(key)) {
+                    if (Object.prototype.hasOwnProperty.call(data['payload'], key)) {
                         const hiddenField = document.createElement('input');
                         hiddenField.type = 'hidden';
                         hiddenField.name = key;


### PR DESCRIPTION
اصلاح باگ اضافه نشدن کوئری پارام ها به URL اصلی در زمان ریدایرکت شدن

در حقیقت مشکل در شرط if بود در کد قبلی تو شرط بررسی میشد که آیا کلید داخل data هست یا خیر در صورتی که کلید در داخل data['payload']  بود و این شرط همیشه false بود 

در نتیجه مشکل بصورت زیر رفع شد