### PR TITLE
Refactor cookie domain handling in logout functionality

### DIFF
--- a/framework_helpers.php
+++ b/framework_helpers.php
@@ -373,38 +373,7 @@ if (!function_exists('request')) {
 if (!function_exists('get_cookie_domain')) {
     function get_cookie_domain(): string
     {
-        $currentHostUrl = parse_url(request()->url(), PHP_URL_HOST);
-        $foreignHostUrl = null;
-        $specialDomains = ['ac.ir', 'gov.ir', 'co.ir'];
-
-        if (env('CORE_URL')) {
-            $foreignHostUrl = parse_url(env('CORE_URL'), PHP_URL_HOST);
-        } elseif (!is_null(setting('_env_client_url'))) {
-            $foreignHostUrl = parse_url(setting('_env_client_url'), PHP_URL_HOST);
-        }
-
-        if (is_null($currentHostUrl) || is_null($foreignHostUrl) || $currentHostUrl == $foreignHostUrl) {
-            return '';
-        }
-
-        $urlParts = explode('.', $currentHostUrl);
-        $topLevelDomain = end($urlParts);
-        $secondLevelDomain = $urlParts[count($urlParts) - 2] ?? '';
-
-        if (count($urlParts) > 2) {
-            $domainEnd = $urlParts[count($urlParts) - 2] . '.' . $urlParts[count($urlParts) - 1];
-            if (in_array($domainEnd, $specialDomains)) {
-                $subDomain = $urlParts[count($urlParts) - 3];
-                return ".$subDomain.$domainEnd";
-            }
-        }
-
-        if (empty($secondLevelDomain)) {
-            return '';
-        }
-
-        // Example: .your-site.com
-        return ".$secondLevelDomain.$topLevelDomain";
+       return parse_url(request()->url(), PHP_URL_HOST);
     }
 }
 

--- a/resources/js/utilities/logout.js
+++ b/resources/js/utilities/logout.js
@@ -8,17 +8,9 @@ export function deleteTokenCookies() {
         var name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
 
         if (name === "token") {
-            // Delete the cookie from current domain
             document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/";
 
-            // Delete the cookie from all subdomains
-            var domainParts = window.location.hostname.split(".");
-            while (domainParts.length > 0) {
-                var domain = domainParts.join(".");
-                document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=." + domain;
-                document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=" + domain; // Without leading dot
-                domainParts.shift();
-            }
+            document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=" + window.location.hostname;
         }
     }
 }

--- a/sdk/Controllers/PWA/PwaController.php
+++ b/sdk/Controllers/PWA/PwaController.php
@@ -270,7 +270,7 @@ class PwaController
     public function logout(Request $request): RedirectResponse
     {
         Authentication::logout();
-        setcookie('token', '', time() - 9999, '/', ".{$_SERVER['HTTP_HOST']}");
+        setcookie('token', '', time() - 9999, '/', get_cookie_domain());
         User::clearUserKeyCookie();
         return new RedirectResponse(site_url('pwa/auth'), 302, []);
     }


### PR DESCRIPTION
- Simplified the get_cookie_domain function to directly return the host from the request URL.
- Updated the logout method in PwaController to use the refined get_cookie_domain function for setting the cookie domain.
- Streamlined the deleteTokenCookies function to remove unnecessary subdomain deletion logic.